### PR TITLE
feat: Auditing 에 필요한 BaseEntity 상속용 클래스 작성

### DIFF
--- a/src/main/java/com/sparta/deliveryapp/DeliveryAppApplication.java
+++ b/src/main/java/com/sparta/deliveryapp/DeliveryAppApplication.java
@@ -3,12 +3,15 @@ package com.sparta.deliveryapp;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
+
+@EnableJpaAuditing
+@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
 public class DeliveryAppApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(DeliveryAppApplication.class, args);
-    }
+  public static void main(String[] args) {
+    SpringApplication.run(DeliveryAppApplication.class, args);
+  }
 
 }

--- a/src/main/java/com/sparta/deliveryapp/auditing/BaseEntity.java
+++ b/src/main/java/com/sparta/deliveryapp/auditing/BaseEntity.java
@@ -1,0 +1,63 @@
+package com.sparta.deliveryapp.auditing;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PreRemove;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+  @CreatedDate
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "created_at", updatable = false)
+  private LocalDateTime createdAt;
+
+//  @CreatedBy
+//  @Column(name = "created_by", updatable = false)
+//  private String createdBy;
+
+  @LastModifiedDate
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "updated_at", updatable = true)
+  private LocalDateTime updatedAt;
+
+//  @LastModifiedBy
+//  @Column(name = "updated_by", updatable = true)
+//  private String updatedBy;
+
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+
+//  @Column(name = "deleted_by")
+//  private String deletedBy;
+
+  @PreRemove
+  public void onPreRemove() {
+    this.deletedAt = LocalDateTime.now();
+    // this.deletedBy = getCurrentUser();
+  }
+
+  private boolean isDeleted() {
+    return deletedAt != null;
+  }
+
+  // TODO: 추후 SecurityContext 가져와야함
+//  private String getCurrentUser() {
+//    // 예시로, Spring Security로 현재 사용자 가져오기
+//    return SecurityContextHolder.getContext().getAuthentication().getName();
+//  }
+}

--- a/src/main/java/com/sparta/deliveryapp/auditing/BaseEntity.java
+++ b/src/main/java/com/sparta/deliveryapp/auditing/BaseEntity.java
@@ -3,6 +3,7 @@ package com.sparta.deliveryapp.auditing;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PreRemove;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 import java.time.LocalDateTime;
@@ -37,9 +38,26 @@ public abstract class BaseEntity {
 //  @Column(name = "updated_by", updatable = true)
 //  private String updatedBy;
 
+
+  @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
+
+//  @Column(name = "deleted_by")
+//  private String deletedBy;
+
+  @PreRemove
+  public void onPreRemove() {
+    this.deletedAt = LocalDateTime.now();
+    // this.deletedBy = getCurrentUser();
+  }
 
   private boolean isDeleted() {
     return deletedAt != null;
   }
+
+  // TODO: 추후 SecurityContext 가져와야함
+//  private String getCurrentUser() {
+//    // 예시로, Spring Security로 현재 사용자 가져오기
+//    return SecurityContextHolder.getContext().getAuthentication().getName();
+//  }
 }

--- a/src/main/java/com/sparta/deliveryapp/auditing/BaseEntity.java
+++ b/src/main/java/com/sparta/deliveryapp/auditing/BaseEntity.java
@@ -1,0 +1,45 @@
+package com.sparta.deliveryapp.auditing;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+  @CreatedDate
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "created_at", updatable = false)
+  private LocalDateTime createdAt;
+
+//  @CreatedBy
+//  @Column(name = "created_by", updatable = false)
+//  private String createdBy;
+
+  @LastModifiedDate
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "updated_at", updatable = true)
+  private LocalDateTime updatedAt;
+
+//  @LastModifiedBy
+//  @Column(name = "updated_by", updatable = true)
+//  private String updatedBy;
+
+  private LocalDateTime deletedAt;
+
+  private boolean isDeleted() {
+    return deletedAt != null;
+  }
+}


### PR DESCRIPTION
## feat: Auditing 에 필요한 BaseEntity 상속용 클래스 작성

### 주요 변경 사항

-  `BaseEntity` 클래스 작성
-  스프링부트 애플리케이션 클래스에 `@EnableJpaAuditing` 추가

### 코드 변경 사항
- `auditing/Basentity.java`  추가됨
- `DeliveryAppApplication` 코드 변경됨

### 전달할 사항
- `BaseEntity` 의 코드 중 생성자와 수정자에 대한 부분은 인증 기능이 merge되지 않아 주석으로 처리함