### PR TITLE
Feature/ scrum 38 상점카테고리관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,24 +67,24 @@ dependencies {
 
 }
 
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
+}
+
 tasks.named('test') {
     useJUnitPlatform()
-
-    // Querydsl 설정부
-    def generated = 'src/main/generated'
-
-    // querydsl QClass 파일 생성 위치를 지정
-    tasks.withType(JavaCompile) {
-        options.getGeneratedSourceOutputDirectory().set(file(generated))
-    }
-
-    // java source set 에 querydsl QClass 위치 추가
-    sourceSets {
-        main.java.srcDirs += [ generated ]
-    }
-
-    // gradle clean 시에 QClass 디렉토리 삭제
-    clean {
-        delete file(generated)
-    }
 }

--- a/src/main/java/com/sparta/deliveryapp/category/controller/CategoryController.java
+++ b/src/main/java/com/sparta/deliveryapp/category/controller/CategoryController.java
@@ -27,4 +27,6 @@ public class CategoryController {
 
     return ResponseEntity.ok().body("카테고리 : " + categoryRequest.getCategoryName() + "이(가) 정상적으로 등록되었습니다.");
   }
+
+  
 }

--- a/src/main/java/com/sparta/deliveryapp/category/controller/CategoryController.java
+++ b/src/main/java/com/sparta/deliveryapp/category/controller/CategoryController.java
@@ -1,0 +1,41 @@
+package com.sparta.deliveryapp.category.controller;
+
+import com.sparta.deliveryapp.category.dto.CategoryResponseDto;
+import com.sparta.deliveryapp.category.entity.Category;
+import com.sparta.deliveryapp.category.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/categories")
+@PreAuthorize("isAuthenticated()")
+public class CategoryController {
+
+  private final CategoryService categoryService;
+
+  @GetMapping("")
+  public ResponseEntity<Page<CategoryResponseDto>> getAllCategories(
+      @PageableDefault(
+          size = 10,
+          page = 0,
+          sort = "createdAt",
+          direction = Direction.ASC) Pageable pageable
+  ) {
+
+    Page<CategoryResponseDto> categoryList = categoryService.getAllCategories(pageable);
+
+    return ResponseEntity.ok().body(categoryList);
+  }
+}

--- a/src/main/java/com/sparta/deliveryapp/category/controller/CategoryController.java
+++ b/src/main/java/com/sparta/deliveryapp/category/controller/CategoryController.java
@@ -3,6 +3,7 @@ package com.sparta.deliveryapp.category.controller;
 import com.sparta.deliveryapp.category.dto.CategoryResponseDto;
 import com.sparta.deliveryapp.category.entity.Category;
 import com.sparta.deliveryapp.category.service.CategoryService;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -13,7 +14,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -38,4 +41,5 @@ public class CategoryController {
 
     return ResponseEntity.ok().body(categoryList);
   }
+
 }

--- a/src/main/java/com/sparta/deliveryapp/category/controller/CategoryController.java
+++ b/src/main/java/com/sparta/deliveryapp/category/controller/CategoryController.java
@@ -1,0 +1,30 @@
+package com.sparta.deliveryapp.category.controller;
+
+import com.sparta.deliveryapp.category.dto.CategoryRequestDto;
+import com.sparta.deliveryapp.category.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/master/categories")
+public class CategoryController {
+
+  private final CategoryService categoryService;
+
+  @PostMapping("/regi")
+  @PreAuthorize("hasAnyAuthority('ROLE_MASTER')")
+  public ResponseEntity<String> regiCategory(@RequestBody CategoryRequestDto categoryRequest) {
+
+    categoryService.regiCategory(categoryRequest.getCategoryName());
+
+    return ResponseEntity.ok().body("카테고리 : " + categoryRequest.getCategoryName() + "이(가) 정상적으로 등록되었습니다.");
+  }
+}

--- a/src/main/java/com/sparta/deliveryapp/category/controller/CategoryMasterController.java
+++ b/src/main/java/com/sparta/deliveryapp/category/controller/CategoryMasterController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,24 +28,47 @@ public class CategoryMasterController {
 
     categoryService.regiCategory(categoryRequest.getCategoryName());
 
-    return ResponseEntity.ok().body("카테고리 : " + categoryRequest.getCategoryName() + "이(가) 정상적으로 등록되었습니다.");
+    return ResponseEntity.ok()
+        .body("카테고리 : " + categoryRequest.getCategoryName() + "이(가) 정상적으로 등록되었습니다.");
   }
 
   //카테고리 이름으로 변경
   @PutMapping("/name")
-  public ResponseEntity<String> updateCategoryUsingName(@RequestBody CategoryUpdateRequestDto categoryUpdateRequestDto) {
+  public ResponseEntity<String> updateCategoryByName(
+      @RequestBody CategoryUpdateRequestDto categoryUpdateRequestDto) {
 
-    categoryService.updateCategoryUsingName(categoryUpdateRequestDto);
+    categoryService.updateCategoryByName(categoryUpdateRequestDto);
 
     return ResponseEntity.ok().body("카테고리가 정상적으로 수정되었습니다.");
   }
 
   //카테고리 id로 변경
   @PutMapping("/id")
-  public ResponseEntity<String> updateCategoryUsingId(@RequestBody CategoryUpdateRequestDto categoryUpdateRequestDto) {
+  public ResponseEntity<String> updateCategoryById(
+      @RequestBody CategoryUpdateRequestDto categoryUpdateRequestDto) {
 
-    categoryService.updateCategoryUsingId(categoryUpdateRequestDto);
+    categoryService.updateCategoryById(categoryUpdateRequestDto);
 
     return ResponseEntity.ok().body("카테고리가 정상적으로 수정되었습니다.");
+  }
+
+  //카테고리 이름으로 삭제
+  @DeleteMapping("/name")
+  public ResponseEntity<String> deleteCategoryByName(
+      @RequestBody CategoryRequestDto categoryRequestDto) {
+
+    categoryService.deleteCategoryByName(categoryRequestDto);
+
+    return ResponseEntity.ok().body("카테고리가 정상적으로 삭제되었습니다.");
+  }
+
+  //카테고리 id로 삭제
+  @DeleteMapping("/id")
+  public ResponseEntity<String> deleteCategoryById(
+      @RequestBody CategoryRequestDto categoryRequestDto) {
+
+    categoryService.deleteCategoryById(categoryRequestDto);
+
+    return ResponseEntity.ok().body("카테고리가 정상적으로 삭제되었습니다.");
   }
 }

--- a/src/main/java/com/sparta/deliveryapp/category/controller/CategoryMasterController.java
+++ b/src/main/java/com/sparta/deliveryapp/category/controller/CategoryMasterController.java
@@ -1,12 +1,14 @@
 package com.sparta.deliveryapp.category.controller;
 
 import com.sparta.deliveryapp.category.dto.CategoryRequestDto;
+import com.sparta.deliveryapp.category.dto.CategoryUpdateRequestDto;
 import com.sparta.deliveryapp.category.service.CategoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,12 +17,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/master/categories")
+@PreAuthorize("hasAnyAuthority('ROLE_MASTER')")
 public class CategoryMasterController {
 
   private final CategoryService categoryService;
 
   @PostMapping("/regi")
-  @PreAuthorize("hasAnyAuthority('ROLE_MASTER')")
   public ResponseEntity<String> regiCategory(@RequestBody CategoryRequestDto categoryRequest) {
 
     categoryService.regiCategory(categoryRequest.getCategoryName());
@@ -28,6 +30,21 @@ public class CategoryMasterController {
     return ResponseEntity.ok().body("카테고리 : " + categoryRequest.getCategoryName() + "이(가) 정상적으로 등록되었습니다.");
   }
 
+  //카테고리 이름으로 변경
+  @PutMapping("/name")
+  public ResponseEntity<String> updateCategoryUsingName(@RequestBody CategoryUpdateRequestDto categoryUpdateRequestDto) {
 
+    categoryService.updateCategoryUsingName(categoryUpdateRequestDto);
 
+    return ResponseEntity.ok().body("카테고리가 정상적으로 수정되었습니다.");
+  }
+
+  //카테고리 id로 변경
+  @PutMapping("/id")
+  public ResponseEntity<String> updateCategoryUsingId(@RequestBody CategoryUpdateRequestDto categoryUpdateRequestDto) {
+
+    categoryService.updateCategoryUsingId(categoryUpdateRequestDto);
+
+    return ResponseEntity.ok().body("카테고리가 정상적으로 수정되었습니다.");
+  }
 }

--- a/src/main/java/com/sparta/deliveryapp/category/controller/CategoryMasterController.java
+++ b/src/main/java/com/sparta/deliveryapp/category/controller/CategoryMasterController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/master/categories")
-public class CategoryController {
+public class CategoryMasterController {
 
   private final CategoryService categoryService;
 
@@ -28,5 +28,6 @@ public class CategoryController {
     return ResponseEntity.ok().body("카테고리 : " + categoryRequest.getCategoryName() + "이(가) 정상적으로 등록되었습니다.");
   }
 
-  
+
+
 }

--- a/src/main/java/com/sparta/deliveryapp/category/controller/CategoryMasterController.java
+++ b/src/main/java/com/sparta/deliveryapp/category/controller/CategoryMasterController.java
@@ -1,17 +1,21 @@
 package com.sparta.deliveryapp.category.controller;
 
 import com.sparta.deliveryapp.category.dto.CategoryRequestDto;
+import com.sparta.deliveryapp.category.dto.CategoryResponseDto;
 import com.sparta.deliveryapp.category.dto.CategoryUpdateRequestDto;
 import com.sparta.deliveryapp.category.service.CategoryService;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -70,5 +74,13 @@ public class CategoryMasterController {
     categoryService.deleteCategoryById(categoryRequestDto);
 
     return ResponseEntity.ok().body("카테고리가 정상적으로 삭제되었습니다.");
+  }
+
+  @GetMapping("")
+  public ResponseEntity<CategoryResponseDto> getCategoryByName(@RequestParam(name = "id") UUID categoryId) {
+
+    CategoryResponseDto categoryResponseDto = categoryService.getCategoryById(categoryId);
+
+    return ResponseEntity.ok().body(categoryResponseDto);
   }
 }

--- a/src/main/java/com/sparta/deliveryapp/category/dto/CategoryRequestDto.java
+++ b/src/main/java/com/sparta/deliveryapp/category/dto/CategoryRequestDto.java
@@ -1,0 +1,18 @@
+package com.sparta.deliveryapp.category.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CategoryRequestDto {
+
+  @NotBlank
+  @JsonProperty("category_name")
+  private String categoryName;
+
+}

--- a/src/main/java/com/sparta/deliveryapp/category/dto/CategoryResponseDto.java
+++ b/src/main/java/com/sparta/deliveryapp/category/dto/CategoryResponseDto.java
@@ -1,0 +1,28 @@
+package com.sparta.deliveryapp.category.dto;
+
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CategoryResponseDto {
+
+  @NotBlank
+  private UUID categoryId;
+
+  @NotBlank
+  private String categoryName;
+
+  @NotBlank
+  private LocalTime createAt;
+}

--- a/src/main/java/com/sparta/deliveryapp/category/dto/CategoryResponseDto.java
+++ b/src/main/java/com/sparta/deliveryapp/category/dto/CategoryResponseDto.java
@@ -2,6 +2,7 @@ package com.sparta.deliveryapp.category.dto;
 
 
 import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -24,5 +25,5 @@ public class CategoryResponseDto {
   private String categoryName;
 
   @NotBlank
-  private LocalTime createAt;
+  private LocalDateTime createAt;
 }

--- a/src/main/java/com/sparta/deliveryapp/category/dto/CategoryUpdateRequestDto.java
+++ b/src/main/java/com/sparta/deliveryapp/category/dto/CategoryUpdateRequestDto.java
@@ -10,13 +10,14 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class CategoryRequestDto {
+public class CategoryUpdateRequestDto {
 
   @JsonProperty("category_id")
   private UUID categoryId;
 
-  @NotBlank
   @JsonProperty("category_name")
   private String categoryName;
 
+  @JsonProperty("new_category_name")
+  private String newCategoryName;
 }

--- a/src/main/java/com/sparta/deliveryapp/category/entity/Category.java
+++ b/src/main/java/com/sparta/deliveryapp/category/entity/Category.java
@@ -1,11 +1,17 @@
 package com.sparta.deliveryapp.category.entity;
 
 import com.sparta.deliveryapp.auditing.BaseEntity;
+import com.sparta.deliveryapp.store.entity.StoreCategory;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/sparta/deliveryapp/category/entity/Category.java
+++ b/src/main/java/com/sparta/deliveryapp/category/entity/Category.java
@@ -1,0 +1,37 @@
+package com.sparta.deliveryapp.category.entity;
+
+import com.sparta.deliveryapp.auditing.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.annotations.Where;
+import org.hibernate.validator.constraints.UniqueElements;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+@Where(clause = "deleted_at IS NULL")
+@Table(name = "p_category")
+public class Category extends BaseEntity {
+
+  @Id
+  @UuidGenerator
+  private UUID categoryId;
+
+  @NotBlank
+  @Column(unique = true)
+  private String categoryName;
+
+}

--- a/src/main/java/com/sparta/deliveryapp/category/entity/StoreCategory.java
+++ b/src/main/java/com/sparta/deliveryapp/category/entity/StoreCategory.java
@@ -1,12 +1,17 @@
 package com.sparta.deliveryapp.category.entity;
 
 import com.sparta.deliveryapp.auditing.BaseEntity;
+import com.sparta.deliveryapp.store.entity.Store;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
 import java.util.UUID;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +21,6 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.annotations.UuidGenerator;
 import org.hibernate.annotations.Where;
-import org.hibernate.validator.constraints.UniqueElements;
 
 @Entity
 @AllArgsConstructor
@@ -24,18 +28,22 @@ import org.hibernate.validator.constraints.UniqueElements;
 @Builder
 @Getter
 @Setter
-@SQLDelete(sql = "UPDATE p_category SET deleted_at=CURRENT_TIMESTAMP WHERE category_id=?")
+@SQLDelete(sql = "UPDATE p_storecategory SET deleted_at=CURRENT_TIMESTAMP WHERE storecategory_id=?")
 @SQLRestriction("deleted_at IS NULL")
-@Table(name = "p_category")
-public class Category extends BaseEntity {
+@Table(name = "p_storecategory")
+public class StoreCategory extends BaseEntity {
 
   @Id
   @UuidGenerator
-  @Column(name = "category_id")
-  private UUID categoryId;
+  @Column(name = "storecategory_id")
+  private UUID storeCategoryId;
 
-  @NotBlank
-  @Column(unique = true)
-  private String categoryName;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "store_id")
+  private Store store;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "category_id")
+  private Category category;
 
 }

--- a/src/main/java/com/sparta/deliveryapp/category/repository/CategoryRepository.java
+++ b/src/main/java/com/sparta/deliveryapp/category/repository/CategoryRepository.java
@@ -4,6 +4,8 @@ import com.sparta.deliveryapp.category.entity.Category;
 import jakarta.validation.constraints.NotBlank;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +17,6 @@ public interface CategoryRepository extends JpaRepository<Category, UUID> {
   Optional<Category> findByCategoryId(UUID categoryId);
 
   Optional<Category> findByCategoryName(@NotBlank String categoryName);
+
+  Page<Category> findAll(Pageable pageable);
 }

--- a/src/main/java/com/sparta/deliveryapp/category/repository/CategoryRepository.java
+++ b/src/main/java/com/sparta/deliveryapp/category/repository/CategoryRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.deliveryapp.category.repository;
+
+import com.sparta.deliveryapp.category.entity.Category;
+import jakarta.validation.constraints.NotBlank;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, UUID> {
+
+  boolean existsByCategoryName(@NotBlank String categoryName);
+}

--- a/src/main/java/com/sparta/deliveryapp/category/repository/CategoryRepository.java
+++ b/src/main/java/com/sparta/deliveryapp/category/repository/CategoryRepository.java
@@ -2,6 +2,7 @@ package com.sparta.deliveryapp.category.repository;
 
 import com.sparta.deliveryapp.category.entity.Category;
 import jakarta.validation.constraints.NotBlank;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +11,8 @@ import org.springframework.stereotype.Repository;
 public interface CategoryRepository extends JpaRepository<Category, UUID> {
 
   boolean existsByCategoryName(@NotBlank String categoryName);
+
+  Optional<Category> findByCategoryName(String categoryName);
+
+  Optional<Category> findByCategoryId(UUID categoryId);
 }

--- a/src/main/java/com/sparta/deliveryapp/category/repository/CategoryRepository.java
+++ b/src/main/java/com/sparta/deliveryapp/category/repository/CategoryRepository.java
@@ -12,7 +12,7 @@ public interface CategoryRepository extends JpaRepository<Category, UUID> {
 
   boolean existsByCategoryName(@NotBlank String categoryName);
 
-  Optional<Category> findByCategoryName(String categoryName);
-
   Optional<Category> findByCategoryId(UUID categoryId);
+
+  Optional<Category> findByCategoryName(@NotBlank String categoryName);
 }

--- a/src/main/java/com/sparta/deliveryapp/category/repository/CategoryRepository.java
+++ b/src/main/java/com/sparta/deliveryapp/category/repository/CategoryRepository.java
@@ -2,6 +2,7 @@ package com.sparta.deliveryapp.category.repository;
 
 import com.sparta.deliveryapp.category.entity.Category;
 import jakarta.validation.constraints.NotBlank;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -19,4 +20,6 @@ public interface CategoryRepository extends JpaRepository<Category, UUID> {
   Optional<Category> findByCategoryName(@NotBlank String categoryName);
 
   Page<Category> findAll(Pageable pageable);
+
+  List<Category> findByCategoryNameIn(List<String> categories);
 }

--- a/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
+++ b/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
@@ -1,14 +1,20 @@
 package com.sparta.deliveryapp.category.service;
 
 import com.sparta.deliveryapp.category.dto.CategoryRequestDto;
+import com.sparta.deliveryapp.category.dto.CategoryResponseDto;
 import com.sparta.deliveryapp.category.dto.CategoryUpdateRequestDto;
 import com.sparta.deliveryapp.category.entity.Category;
 import com.sparta.deliveryapp.category.repository.CategoryRepository;
 import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -136,5 +142,21 @@ public class CategoryService {
     } catch (Exception e) {
       throw new RuntimeException("카테고리 삭제 실패");
     }
+  }
+
+  public Page<CategoryResponseDto> getAllCategories(Pageable pageable) {
+
+    Page<CategoryResponseDto> categoryList = categoryRepository.findAll(pageable)
+        .map(category -> CategoryResponseDto.builder()
+            .categoryId(category.getCategoryId())
+            .categoryName(category.getCategoryName())
+            .build());
+
+
+    if (categoryList.isEmpty()) {
+      throw new NoSuchElementException("등록된 카테고리가 없습니다.");
+    }
+
+    return categoryList;
   }
 }

--- a/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
+++ b/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
@@ -22,26 +22,26 @@ public class CategoryService {
   @Transactional
   public void regiCategory(String categoryName) {
 
-    if(categoryRepository.existsByCategoryName(categoryName)){
+    if (categoryRepository.existsByCategoryName(categoryName)) {
       throw new IllegalArgumentException("동일한 카테고리가 존재합니다.");
     }
     Category category = new Category();
     category.setCategoryName(categoryName);
 
-    try{
+    try {
       categoryRepository.save(category);
-    }
-    catch (Exception e){
-      log.error(e.getMessage()+"카테고리 등록 실패");
+    } catch (Exception e) {
       throw new IllegalArgumentException("카테고리 등록이 실패했습니다.");
     }
 
   }
 
-  public void updateCategoryUsingName(CategoryUpdateRequestDto categoryUpdateRequestDto) {
+  public void updateCategoryByName(CategoryUpdateRequestDto categoryUpdateRequestDto) {
 
-    String categoryName = categoryUpdateRequestDto.getCategoryName() == null ? "" : categoryUpdateRequestDto.getCategoryName();
-    String newCategoryName = categoryUpdateRequestDto.getNewCategoryName() == null ? "" : categoryUpdateRequestDto.getNewCategoryName();
+    String categoryName = categoryUpdateRequestDto.getCategoryName() == null ? ""
+        : categoryUpdateRequestDto.getCategoryName();
+    String newCategoryName = categoryUpdateRequestDto.getNewCategoryName() == null ? ""
+        : categoryUpdateRequestDto.getNewCategoryName();
 
     if (categoryName.isEmpty() || newCategoryName.isEmpty()) {
       throw new IllegalArgumentException("카테고리나 새로운 카테고리가 입력되지 않았습니다.");
@@ -60,25 +60,24 @@ public class CategoryService {
     try {
       categoryRepository.save(category);  // 카테고리 저장
     } catch (Exception e) {
-      log.error("카테고리 업데이트 실패: " + e.getMessage());
       throw new RuntimeException("카테고리 업데이트에 실패했습니다.");
     }
   }
 
+  public void updateCategoryById(CategoryUpdateRequestDto categoryUpdateRequestDto) {
 
-  public void updateCategoryUsingId(CategoryUpdateRequestDto categoryUpdateRequestDto) {
+    UUID categoryId = categoryUpdateRequestDto.getCategoryId();
+    String newCategoryName = categoryUpdateRequestDto.getNewCategoryName() == null ? ""
+        : categoryUpdateRequestDto.getNewCategoryName();
 
-    String categoryId = categoryUpdateRequestDto.getCategoryId() == null? "" : String.valueOf(categoryUpdateRequestDto.getCategoryId());
-    String newCategoryName = categoryUpdateRequestDto.getNewCategoryName() == null ? "" : categoryUpdateRequestDto.getNewCategoryName();
-
-    if (categoryId.trim().isEmpty()) {
+    if (categoryId == null) {
       throw new IllegalArgumentException("카테고리 id가 비어있습니다.");
     }
-    if(newCategoryName.trim().isEmpty()){
+    if (newCategoryName.trim().isEmpty()) {
       throw new IllegalArgumentException("카테고리 명이 없습니다.");
     }
 
-    Optional<Category> categoryOptional = categoryRepository.findByCategoryId(UUID.fromString(categoryId));
+    Optional<Category> categoryOptional = categoryRepository.findByCategoryId(categoryId);
 
     if (categoryOptional.isEmpty()) {
       throw new IllegalArgumentException("존재하지 않는 카테고리 id입니다.");
@@ -91,10 +90,51 @@ public class CategoryService {
     try {
       categoryRepository.save(category);  // 카테고리 저장
     } catch (Exception e) {
-      log.error("카테고리 업데이트 실패: " + e.getMessage());
       throw new RuntimeException("카테고리 업데이트에 실패했습니다.");
     }
   }
 
 
+  public void deleteCategoryByName(CategoryRequestDto categoryRequestDto) {
+
+    String categoryName =
+        categoryRequestDto.getCategoryName() == null ? "" : categoryRequestDto.getCategoryName();
+
+    if (categoryName.isEmpty()) {
+      throw new IllegalArgumentException("카테고리가 입력되지 않았습니다.");
+    }
+
+    Optional<Category> categoryOptional = categoryRepository.findByCategoryName(categoryName);
+
+    if (categoryOptional.isEmpty()) {
+      throw new IllegalArgumentException("존재하지 않는 카테고리입니다.");
+    }
+
+    try {
+      categoryRepository.delete(categoryOptional.get());
+    } catch (Exception e) {
+      throw new RuntimeException("카테고리 삭제 실패");
+    }
+
+  }
+
+  public void deleteCategoryById(CategoryRequestDto categoryRequestDto) {
+    UUID categoryId = categoryRequestDto.getCategoryId();
+
+    if (categoryId == null) {
+      throw new IllegalArgumentException("카테고리가 입력되지 않았습니다.");
+    }
+
+    Optional<Category> categoryOptional = categoryRepository.findByCategoryId(categoryId);
+
+    if (categoryOptional.isEmpty()) {
+      throw new IllegalArgumentException("존재하지 않는 카테고리입니다.");
+    }
+
+    try {
+      categoryRepository.delete(categoryOptional.get());
+    } catch (Exception e) {
+      throw new RuntimeException("카테고리 삭제 실패");
+    }
+  }
 }

--- a/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
+++ b/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
@@ -150,6 +150,7 @@ public class CategoryService {
         .map(category -> CategoryResponseDto.builder()
             .categoryId(category.getCategoryId())
             .categoryName(category.getCategoryName())
+            .createAt(category.getCreatedAt())
             .build());
 
 

--- a/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
+++ b/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
@@ -1,11 +1,14 @@
 package com.sparta.deliveryapp.category.service;
 
+import com.sparta.deliveryapp.category.dto.CategoryRequestDto;
+import com.sparta.deliveryapp.category.dto.CategoryUpdateRequestDto;
 import com.sparta.deliveryapp.category.entity.Category;
 import com.sparta.deliveryapp.category.repository.CategoryRepository;
 import jakarta.transaction.Transactional;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -34,4 +37,64 @@ public class CategoryService {
     }
 
   }
+
+  public void updateCategoryUsingName(CategoryUpdateRequestDto categoryUpdateRequestDto) {
+
+    String categoryName = categoryUpdateRequestDto.getCategoryName() == null ? "" : categoryUpdateRequestDto.getCategoryName();
+    String newCategoryName = categoryUpdateRequestDto.getNewCategoryName() == null ? "" : categoryUpdateRequestDto.getNewCategoryName();
+
+    if (categoryName.isEmpty() || newCategoryName.isEmpty()) {
+      throw new IllegalArgumentException("카테고리나 새로운 카테고리가 입력되지 않았습니다.");
+    }
+
+    Optional<Category> categoryOptional = categoryRepository.findByCategoryName(categoryName);
+
+    if (categoryOptional.isEmpty()) {
+      throw new IllegalArgumentException("존재하지 않는 카테고리입니다.");
+    }
+
+    Category category = categoryOptional.get();
+
+    category.setCategoryName(categoryUpdateRequestDto.getNewCategoryName());
+
+    try {
+      categoryRepository.save(category);  // 카테고리 저장
+    } catch (Exception e) {
+      log.error("카테고리 업데이트 실패: " + e.getMessage());
+      throw new RuntimeException("카테고리 업데이트에 실패했습니다.");
+    }
+  }
+
+
+  public void updateCategoryUsingId(CategoryUpdateRequestDto categoryUpdateRequestDto) {
+
+    String categoryId = categoryUpdateRequestDto.getCategoryId() == null? "" : String.valueOf(categoryUpdateRequestDto.getCategoryId());
+    String newCategoryName = categoryUpdateRequestDto.getNewCategoryName() == null ? "" : categoryUpdateRequestDto.getNewCategoryName();
+
+    if (categoryId.trim().isEmpty()) {
+      throw new IllegalArgumentException("카테고리 id가 비어있습니다.");
+    }
+    if(newCategoryName.trim().isEmpty()){
+      throw new IllegalArgumentException("카테고리 명이 없습니다.");
+    }
+
+    Optional<Category> categoryOptional = categoryRepository.findByCategoryId(UUID.fromString(categoryId));
+
+    if (categoryOptional.isEmpty()) {
+      throw new IllegalArgumentException("존재하지 않는 카테고리 id입니다.");
+    }
+
+    Category category = categoryOptional.get();
+
+    category.setCategoryName(categoryUpdateRequestDto.getNewCategoryName());
+
+    try {
+      categoryRepository.save(category);  // 카테고리 저장
+    } catch (Exception e) {
+      log.error("카테고리 업데이트 실패: " + e.getMessage());
+      throw new RuntimeException("카테고리 업데이트에 실패했습니다.");
+    }
+  }
+
+
 }

--- a/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
+++ b/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
@@ -1,0 +1,37 @@
+package com.sparta.deliveryapp.category.service;
+
+import com.sparta.deliveryapp.category.entity.Category;
+import com.sparta.deliveryapp.category.repository.CategoryRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+  private final CategoryRepository categoryRepository;
+
+  //todo: throws로 구현할지 생각해보기
+  @Transactional
+  public void regiCategory(String categoryName) {
+
+    if(categoryRepository.existsByCategoryName(categoryName)){
+      throw new IllegalArgumentException("동일한 카테고리가 존재합니다.");
+    }
+    Category category = new Category();
+    category.setCategoryName(categoryName);
+
+    try{
+      categoryRepository.save(category);
+    }
+    catch (Exception e){
+      log.error(e.getMessage()+"카테고리 등록 실패");
+      throw new IllegalArgumentException("카테고리 등록이 실패했습니다.");
+    }
+
+  }
+}

--- a/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
+++ b/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
@@ -160,4 +160,28 @@ public class CategoryService {
 
     return categoryList;
   }
+
+  public CategoryResponseDto getCategoryById(UUID categoryId) {
+
+    if(categoryId == null){
+      throw new IllegalArgumentException("카테고리 id가 없습니다.");
+    }
+
+    Optional<Category> category = categoryRepository.findByCategoryId(categoryId);
+
+    if(category.isEmpty()){
+      throw new NoSuchElementException("카테고리 id에 매칭되는 카테고리가 없습니다.");
+    }
+
+    CategoryResponseDto categoryResponseDto = category.map(o ->
+        CategoryResponseDto.builder()
+            .categoryId(o.getCategoryId())
+            .categoryName(o.getCategoryName())
+            .createAt(o.getCreatedAt())
+            .build()
+    ).orElseThrow(() -> new IllegalArgumentException("카테고리 없음"));
+
+    return categoryResponseDto;
+
+  }
 }

--- a/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
+++ b/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
@@ -24,7 +24,6 @@ public class CategoryService {
 
   private final CategoryRepository categoryRepository;
 
-  //todo: throws로 구현할지 생각해보기
   @Transactional
   public void regiCategory(String categoryName) {
 
@@ -184,4 +183,6 @@ public class CategoryService {
     return categoryResponseDto;
 
   }
+
+
 }

--- a/src/main/java/com/sparta/deliveryapp/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/deliveryapp/store/controller/StoreController.java
@@ -1,10 +1,12 @@
 package com.sparta.deliveryapp.store.controller;
 
 import com.sparta.deliveryapp.store.dto.StoreNearbyStoreResponseDto;
+import com.sparta.deliveryapp.store.dto.StoreNearbyStoreWithCategoryResponseDto;
 import com.sparta.deliveryapp.store.dto.StoreRequestDto;
 import com.sparta.deliveryapp.store.service.StoreService;
 import com.sparta.deliveryapp.user.security.UserDetailsImpl;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -46,7 +48,7 @@ public class StoreController {
   public ResponseEntity<Page<StoreNearbyStoreResponseDto>> getNearbyStoresWithoutCategory(
       @RequestParam(value = "longitude") double longitude,
       @RequestParam(value = "latitude") double latitude,
-      @PageableDefault(
+      @PageableDefault( //todo: 등록시간 기준 최신순, 오래된 순을 기본 정렬 조건으로, 차후 정렬 조건으로 거리순
           size = 10,
           page = 0,
           sort = "distanceFromRequest",
@@ -59,5 +61,23 @@ public class StoreController {
     return ResponseEntity.ok().body(storeResponseDto);
   }
 
+  //카테고리에 해당하는 주변 가게 검색
+  @GetMapping("/locandcat")
+  @PreAuthorize("isAuthenticated()")
+  public ResponseEntity<Page<StoreNearbyStoreWithCategoryResponseDto>> getNearbyStoresWithCategory(
+      @RequestParam(value = "category") List<String> categoryNames,
+      @RequestParam(value = "longitude") double longitude,
+      @RequestParam(value = "latitude") double latitude,
+      @PageableDefault( //todo: 등록시간 기준 최신순, 오래된 순을 기본 정렬 조건으로, 차후 정렬 조건으로 거리순
+          size = 10,
+          page = 0,
+          sort = "distanceFromRequest",
+          direction = Direction.ASC) Pageable pageable) {
+
+    Page<StoreNearbyStoreWithCategoryResponseDto> storeDtos = storeService.findNearbyStoresByCategory(
+        categoryNames, longitude, latitude, pageable);
+
+    return ResponseEntity.ok().body(storeDtos);
+  }
 
 }

--- a/src/main/java/com/sparta/deliveryapp/store/dto/StoreNearbyStoreWithCategoryResponseDto.java
+++ b/src/main/java/com/sparta/deliveryapp/store/dto/StoreNearbyStoreWithCategoryResponseDto.java
@@ -1,0 +1,46 @@
+package com.sparta.deliveryapp.store.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+// 응답 값에 거리와 카테고리가 포함된 가게 정보 DTO
+public class StoreNearbyStoreWithCategoryResponseDto {
+
+  @NotNull
+  private UUID storeId;
+
+  @NotBlank
+  private String storeName;
+
+  @NotBlank
+  private String address;
+
+  @NotBlank
+  private String bRegiNum;
+
+  @NotNull
+  private LocalTime openAt;
+
+  @NotNull
+  private LocalTime closeAt;
+
+  private List<String> categories;
+
+  private Double distanceFromRequest;
+
+//  private Double rating;
+
+}

--- a/src/main/java/com/sparta/deliveryapp/store/dto/StoreRequestDto.java
+++ b/src/main/java/com/sparta/deliveryapp/store/dto/StoreRequestDto.java
@@ -3,6 +3,7 @@ package com.sparta.deliveryapp.store.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,4 +32,7 @@ public class StoreRequestDto {
   @NotNull
   @JsonProperty("close_at")
   private String closeAt;
+
+  @JsonProperty("category")
+  private List<String> categories;
 }

--- a/src/main/java/com/sparta/deliveryapp/store/entity/Store.java
+++ b/src/main/java/com/sparta/deliveryapp/store/entity/Store.java
@@ -1,16 +1,21 @@
 package com.sparta.deliveryapp.store.entity;
 
 import com.sparta.deliveryapp.auditing.BaseEntity;
+import com.sparta.deliveryapp.category.entity.Category;
 import com.sparta.deliveryapp.user.entity.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -47,9 +52,6 @@ public class Store extends BaseEntity {
   @Column(name = "b_regi_num", nullable = false)
   private String bRegiNum;
 
-  @Column(name = "rating")
-  private Double rating;
-
   @Column(name = "open_at")
   private LocalTime openAt;
 
@@ -68,6 +70,26 @@ public class Store extends BaseEntity {
 
   public boolean isAssociated(User user) {
     return this.user.equals(user);
+  }
+
+  @Builder.Default
+  @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<StoreCategory> storeCategories = new ArrayList<>();
+
+  @Transient
+  public List<Category> getCategories() {
+    List<Category> categories = new ArrayList<>();
+    for (StoreCategory storeCategory : storeCategories) {
+      categories.add(storeCategory.getCategory());
+    }
+    return categories;
+  }
+
+  public void addCategory(Category category) {
+    StoreCategory storeCategory = new StoreCategory();
+    storeCategory.setStore(this);
+    storeCategory.setCategory(category);
+    this.storeCategories.add(storeCategory);
   }
 
 }

--- a/src/main/java/com/sparta/deliveryapp/store/entity/Store.java
+++ b/src/main/java/com/sparta/deliveryapp/store/entity/Store.java
@@ -21,6 +21,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.UuidGenerator;
 import org.hibernate.annotations.Where;
 import org.locationtech.jts.geom.Point;
@@ -29,6 +30,7 @@ import org.locationtech.jts.geom.Point;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Setter
 @Getter
 @Where(clause = "deleted_at IS NULL")
 @Table(name = "p_store")
@@ -72,9 +74,8 @@ public class Store extends BaseEntity {
     return this.user.equals(user);
   }
 
-  @Builder.Default
   @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<StoreCategory> storeCategories = new ArrayList<>();
+  private List<StoreCategory> storeCategories;
 
   @Transient
   public List<Category> getCategories() {
@@ -83,13 +84,6 @@ public class Store extends BaseEntity {
       categories.add(storeCategory.getCategory());
     }
     return categories;
-  }
-
-  public void addCategory(Category category) {
-    StoreCategory storeCategory = new StoreCategory();
-    storeCategory.setStore(this);
-    storeCategory.setCategory(category);
-    this.storeCategories.add(storeCategory);
   }
 
 }

--- a/src/main/java/com/sparta/deliveryapp/store/entity/StoreCategory.java
+++ b/src/main/java/com/sparta/deliveryapp/store/entity/StoreCategory.java
@@ -1,17 +1,15 @@
-package com.sparta.deliveryapp.category.entity;
+package com.sparta.deliveryapp.store.entity;
 
 import com.sparta.deliveryapp.auditing.BaseEntity;
-import com.sparta.deliveryapp.store.entity.Store;
+import com.sparta.deliveryapp.category.entity.Category;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.util.UUID;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,7 +18,6 @@ import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.annotations.UuidGenerator;
-import org.hibernate.annotations.Where;
 
 @Entity
 @AllArgsConstructor

--- a/src/main/java/com/sparta/deliveryapp/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/deliveryapp/store/repository/StoreRepository.java
@@ -1,6 +1,7 @@
 package com.sparta.deliveryapp.store.repository;
 
 import com.sparta.deliveryapp.store.dto.StoreNearbyStoreResponseDto;
+import com.sparta.deliveryapp.store.dto.StoreNearbyStoreWithCategoryResponseDto;
 import com.sparta.deliveryapp.store.entity.Store;
 import com.sparta.deliveryapp.user.entity.User;
 import jakarta.validation.constraints.NotBlank;
@@ -23,9 +24,19 @@ public interface StoreRepository extends JpaRepository<Store, UUID>, StoreReposi
 
   Page<Store> findByStoreNameContaining(String storeName, Pageable pageable);
 
+
 }
 
 interface StoreRepositoryCustom {
-  Page<StoreNearbyStoreResponseDto> findNearbyStoresWithoutCategory(double longitude, double latitude, int range,
+
+  Page<StoreNearbyStoreResponseDto> findNearbyStoresWithoutCategory(double longitude,
+      double latitude, int range,
+      Pageable pageable);
+
+  Page<StoreNearbyStoreWithCategoryResponseDto> findNearbyStoresByCategories(
+      List<String> categoryNames,
+      double longitude,
+      double latitude,
+      int range,
       Pageable pageable);
 }

--- a/src/main/java/com/sparta/deliveryapp/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/sparta/deliveryapp/store/repository/StoreRepositoryImpl.java
@@ -1,13 +1,18 @@
 package com.sparta.deliveryapp.store.repository;
 
+
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.deliveryapp.category.entity.QCategory;
 import com.sparta.deliveryapp.store.dto.StoreNearbyStoreResponseDto;
+import com.sparta.deliveryapp.store.dto.StoreNearbyStoreWithCategoryResponseDto;
 import com.sparta.deliveryapp.store.entity.QStore;
+import com.sparta.deliveryapp.store.entity.QStoreCategory;
 import jakarta.persistence.EntityManager;
 import java.time.LocalTime;
 import java.util.List;
@@ -26,6 +31,7 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
     this.queryFactory = new JPAQueryFactory(entityManager);
   }
 
+  //todo: 리뷰 계산 추가하기
   @Override
   public Page<StoreNearbyStoreResponseDto> findNearbyStoresWithoutCategory(double longitude,
       double latitude, int range, Pageable pageable) {
@@ -72,8 +78,90 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
   }
 
 
+  //todo: 리뷰 테이블과 연결하고 리뷰 컬럼 계산 추가하기
+  @Override
+  public Page<StoreNearbyStoreWithCategoryResponseDto> findNearbyStoresByCategories(
+      List<String> categoryNames,
+      double longitude,
+      double latitude,
+      int range,
+      Pageable pageable
+  ) {
+
+    QStore store = QStore.store;
+    QStoreCategory storeCategory = QStoreCategory.storeCategory;
+    QCategory category = QCategory.category;
+
+    JPAQuery<Tuple> query = queryFactory
+        .select(
+            store.storeId,
+            store.storeName,
+            store.address,
+            store.bRegiNum,
+            store.openAt,
+            store.closeAt,
+            Expressions.numberTemplate(
+                Double.class,
+                "ST_Distance(geography(ST_SetSRID(ST_Point({0}, {1}), 4326)), geography(ST_SetSRID(ST_Point({2}, {3}), 4326)))",
+                longitude, latitude,
+                store.storeCoordX,
+                store.storeCoordY
+            ).as("distanceFromRequest")
+//            Expressions.numberTemplate(
+//                Double.class,
+//                "COALESCE(AVG(review.rating), 0)",
+//                review.rating
+//            ).as("averageRating")
+        )
+        .from(store)
+        .innerJoin(store.storeCategories, storeCategory)
+        .innerJoin(storeCategory.category, category)
+//        .leftJoin(store.reviews, review)
+        .where(
+            category.categoryName.in(categoryNames),
+            Expressions.numberTemplate(
+                Double.class,
+                "ST_Distance(geography(ST_SetSRID(ST_Point({0}, {1}), 4326)), geography(ST_SetSRID(ST_Point({2}, {3}), 4326)))",
+                longitude, latitude,
+                store.storeCoordX,
+                store.storeCoordY
+            ).lt(range)
+        )
+//        .orderBy(
+//            Expressions.numberTemplate(
+//                Double.class,
+//                "ST_Distance(geography(ST_SetSRID(ST_Point({0}, {1}), 4326)), geography(ST_SetSRID(ST_Point({2}, {3}), 4326)))",
+//                longitude, latitude,
+//                store.storeCoordX,
+//                store.storeCoordY
+//            ).asc()
+//        )
+        .groupBy(store.storeId)
+        .distinct() // 중복 제거
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize());
+
+    QueryResults<Tuple> results = query.fetchResults();
+
+    List<StoreNearbyStoreWithCategoryResponseDto> content = results.getResults().stream()
+        .map(tuple -> StoreNearbyStoreWithCategoryResponseDto.builder()
+            .storeId(tuple.get(store.storeId))
+            .storeName(tuple.get(store.storeName))
+            .address(tuple.get(store.address))
+            .bRegiNum(tuple.get(store.bRegiNum))
+            .openAt(tuple.get(store.openAt))
+            .closeAt(tuple.get(store.closeAt))
+            .distanceFromRequest(tuple.get(6, Double.class))
+//            .rating(tuple.get(7, Double.class))
+            .build())
+        .toList();
+
+    return new PageImpl<>(content, pageable, results.getTotal());
+  }
+
   private BooleanExpression geoDistance(double longitude, double latitude,
       NumberPath<Double> storeX, NumberPath<Double> storeY, int range) {
+
     return Expressions.numberTemplate(Double.class,
         "ST_Distance(geography(ST_SetSRID(ST_Point({0}, {1}), 4326)), geography(ST_SetSRID(ST_Point({2}, {3}), 4326)))",
         longitude, latitude,

--- a/src/main/java/com/sparta/deliveryapp/store/service/StoreService.java
+++ b/src/main/java/com/sparta/deliveryapp/store/service/StoreService.java
@@ -1,6 +1,7 @@
 package com.sparta.deliveryapp.store.service;
 
 import com.sparta.deliveryapp.store.dto.StoreNearbyStoreResponseDto;
+import com.sparta.deliveryapp.store.dto.StoreNearbyStoreWithCategoryResponseDto;
 import com.sparta.deliveryapp.store.dto.StoreRequestDto;
 import com.sparta.deliveryapp.store.dto.StoreResponseDto;
 import com.sparta.deliveryapp.store.entity.Store;
@@ -55,7 +56,7 @@ public class StoreService {
         .address(storeRequestDto.getAddress()).bRegiNum(storeRequestDto.getBRegiNum())
         .storeCoordX(storeCoords[0]) // x:경도
         .storeCoordY(storeCoords[1])  // y:위도
-        .rating(0.0)
+//        .rating(0.0)
         .openAt(convertStringToTimestamp(storeRequestDto.getOpenAt()))
         .closeAt(convertStringToTimestamp(storeRequestDto.getCloseAt()))
         .user(userDetails.getUser())
@@ -127,7 +128,8 @@ public class StoreService {
     return storeResponseDto;
   }
 
-  public Page<StoreNearbyStoreResponseDto> findNearbyStoresWithoutCategory(double longitude, double latitude,
+  public Page<StoreNearbyStoreResponseDto> findNearbyStoresWithoutCategory(double longitude,
+      double latitude,
       Pageable pageable) {
     final int RANGE = 3000;
 
@@ -135,7 +137,8 @@ public class StoreService {
       throw new IllegalArgumentException("주어진 좌표의 자릿수가 너무 작습니다.");
     }
 
-    Page<StoreNearbyStoreResponseDto> nearbyStores = storeRepository.findNearbyStoresWithoutCategory(longitude,
+    Page<StoreNearbyStoreResponseDto> nearbyStores = storeRepository.findNearbyStoresWithoutCategory(
+        longitude,
         latitude, RANGE, pageable);
 
     if (nearbyStores.isEmpty()) {
@@ -176,4 +179,27 @@ public class StoreService {
   }
 
 
+  public Page<StoreNearbyStoreWithCategoryResponseDto> findNearbyStoresByCategory(
+      List<String> categoryNames,
+      double longitude, double latitude, Pageable pageable) {
+    final int RANGE = 3000;
+
+    if (getDecimalPlaces(longitude) < 2 || getDecimalPlaces(latitude) < 2) {
+      throw new IllegalArgumentException("주어진 좌표의 자릿수가 너무 작습니다.");
+    }
+
+    //카테고리 목록 뭘로할지 생각해보기
+    Page<StoreNearbyStoreWithCategoryResponseDto> nearbyStores = storeRepository.findNearbyStoresByCategories(
+        categoryNames,
+        longitude,
+        latitude,
+        RANGE,
+        pageable);
+
+    if (nearbyStores.isEmpty()) {
+      throw new NoSuchElementException("카테고리에 해당하는 근처 가게가 없습니다.");
+    }
+
+    return nearbyStores;
+  }
 }


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 가게 등록 시 storeRequestDto에 카테고리 리스트 없었음

- **to-be**
- 카테고리 엔티티, 가게-카테고리 엔티티 생성
- 카테고리 CUD, search 기능 구현
- 상점 조회 시 카테고리 파라미터한 카테고리별 근처 가게 조회 기능 구현
- build.gradle에 query dsl 관련 설정 위치 재배치
- 가게/카테고리 중간 테이블 연관 관계 지정
- store 엔티티에 가게-카테고리 엔티티에 연관관계 설정 및 mappedby 설정
- 가게 등록 시 클라이언트에서 입력한 카테고리 파라미터 필드 추가
- 가게 엔티티 조회 시 중간 테이블 이용하여 카테고리 정보 불러올 때 fetch join 사용하여 n+1 문제 대응

## 코멘트
- 리뷰 테이블이 아직 dev에 병합되지 않아, 리뷰 평점 구현 기능은 미구현 하였습니다.
