### PR TITLE
fix: 가게 조회 기능 안되던거 수정

### DIFF
--- a/src/main/java/com/sparta/deliveryapp/category/controller/CategoryMasterController.java
+++ b/src/main/java/com/sparta/deliveryapp/category/controller/CategoryMasterController.java
@@ -87,9 +87,9 @@ public class CategoryMasterController {
   @GetMapping("")
   @Operation(summary = "카테고리 검색 기능(이름 기준)", description = "등록된 카테고리 이름으로 검색하여 정보를 조회하는 API")
   public ResponseEntity<CategoryResponseDto> getCategoryByName(
-      @RequestParam(name = "id") UUID categoryId) {
+      @RequestParam(name = "name") String categoryName) {
 
-    CategoryResponseDto categoryResponseDto = categoryService.getCategoryById(categoryId);
+    CategoryResponseDto categoryResponseDto = categoryService.getCategoryById(categoryName);
 
     return ResponseEntity.ok().body(categoryResponseDto);
   }

--- a/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
+++ b/src/main/java/com/sparta/deliveryapp/category/service/CategoryService.java
@@ -171,13 +171,13 @@ public class CategoryService {
     return categoryList;
   }
 
-  public CategoryResponseDto getCategoryById(UUID categoryId) {
+  public CategoryResponseDto getCategoryById(String categoryId) {
 
     if (categoryId == null) {
       throw new CustomException(NOT_EXISTS_INPUT_CATEGORY_DATA);
     }
 
-    Optional<Category> category = categoryRepository.findByCategoryId(categoryId);
+    Optional<Category> category = categoryRepository.findByCategoryName(categoryId);
 
     if (category.isEmpty()) {
       throw new CustomException(NOT_EXISTS_INPUT_CATEGORY_DATA);

--- a/src/main/java/com/sparta/deliveryapp/store/service/StoreService.java
+++ b/src/main/java/com/sparta/deliveryapp/store/service/StoreService.java
@@ -322,6 +322,8 @@ public class StoreService {
         .openAt(convertStringToTimestamp(storeRequestDto.getOpenAt()))
         .closeAt(convertStringToTimestamp(storeRequestDto.getCloseAt()))
         .user(userDetails.getUser())
+        .storeCoordX(existingStore.getStoreCoordX())
+        .storeCoordY(existingStore.getStoreCoordY())
         .storeCategories(existingStore.getStoreCategories())
         .build();
 


### PR DESCRIPTION
## 변경 타입
- [ ] 신규 기능 추가/수정
- [x] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 가게 이름으로 검색, 가게 주문 조회 기능 403으로 실행 불가

- **to-be**
  - 정상적으로 실행
  - 가게 수정 시 좌표값은 기존 저장소에서 가져옴
  - 카테고리 이름으로 검색 기능 파라미터 이름으로 수정

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)
