### PR TITLE
Feature/user redis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     // hibernate-spatial
     implementation 'org.hibernate.orm:hibernate-spatial'
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 // Querydsl 설정부

--- a/src/main/java/com/sparta/deliveryapp/commons/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/deliveryapp/commons/exception/ErrorCode.java
@@ -65,9 +65,11 @@ public enum ErrorCode {
   ACCESS_DENIED_ONLY_USER_ID(HttpStatus.NOT_FOUND, "PAY_003", "본인의 결제 정보만 조회 가능합니다."),
   NOT_SUFFICIENT_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "PAY_004", "결제 금액은 1원 이상이어야 합니다."),
   NOT_PAYMENT(HttpStatus.BAD_REQUEST, "PAY_005", "결제 중 오류가 발생했습니다."),
-  NOT_PAYMENT_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PAY_006", "결제 처리 중 오류가 발생했습니다.");
+  NOT_PAYMENT_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PAY_006", "결제 처리 중 오류가 발생했습니다."),
 
-
+  // Refresh Token
+  EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN_001", "리프레시 토큰이 만료되었거나 유효하지 않습니다."),
+  INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN_002", "리프레시 토큰이 올바르지 않습니다.");
 
   private final String code;
   private final String message;

--- a/src/main/java/com/sparta/deliveryapp/config/RedisConfig.java
+++ b/src/main/java/com/sparta/deliveryapp/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.sparta.deliveryapp.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+@Configuration
+@Slf4j
+public class RedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String redisHost;
+
+  @Value("${spring.data.redis.port}")
+  private int redisPort;
+
+  @Value("${spring.data.redis.password}")
+  private String redisPassword;  // 비밀번호를 주입받기
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    LettuceConnectionFactory factory = new LettuceConnectionFactory(redisHost, redisPort);
+    if (redisPassword != null && !redisPassword.isEmpty()) {
+      factory.setPassword(redisPassword);  // 비밀번호 설정
+    }
+    return factory;
+  }
+
+  @Bean
+  public RedisTemplate<String, String> redisTemplate() {
+    RedisTemplate<String, String> template = new RedisTemplate<>();
+    template.setConnectionFactory(redisConnectionFactory());
+    template.setKeySerializer(RedisSerializer.string());
+    template.setValueSerializer(RedisSerializer.json());
+    return template;
+  }
+}

--- a/src/main/java/com/sparta/deliveryapp/config/WebSecurityConfig.java
+++ b/src/main/java/com/sparta/deliveryapp/config/WebSecurityConfig.java
@@ -7,6 +7,7 @@ import com.sparta.deliveryapp.user.security.UserDetailsServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -26,7 +27,8 @@ public class WebSecurityConfig {
 
   private final JwtUtil jwtUtil;
   private final UserDetailsServiceImpl userDetailsService;
-  private final AuthenticationConfiguration authenticationConfiguration;
+  private final RedisTemplate<String, String> redisTemplate;
+
 
   @Bean
   public PasswordEncoder passwordEncoder() {
@@ -41,7 +43,7 @@ public class WebSecurityConfig {
 
   @Bean
   public JwtAuthorizationFilter jwtAuthorizationFilter() {
-    return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+    return new JwtAuthorizationFilter(jwtUtil, userDetailsService,redisTemplate);
   }
 
 

--- a/src/main/java/com/sparta/deliveryapp/user/controller/UserController.java
+++ b/src/main/java/com/sparta/deliveryapp/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.sparta.deliveryapp.user.controller;
 
 import com.sparta.deliveryapp.user.dto.*;
 import com.sparta.deliveryapp.user.security.UserDetailsImpl;
+import com.sparta.deliveryapp.user.service.RefreshTokenService;
 import com.sparta.deliveryapp.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -28,6 +29,7 @@ import java.util.Map;
 public class UserController {
 
   private final UserService userService;
+  private final RefreshTokenService refreshTokenService;
 
   @Operation(summary = "회원가입 기능", description = "회원가입 하는 api")
   @ApiResponse(responseCode = "200",description = "회원가입 성공")
@@ -86,6 +88,13 @@ public class UserController {
     String email = userDetails.getUser().getEmail();
     return userService.getUser(email, userDetails.getUser());
 
+  }
+
+  @PostMapping("/refresh-token")
+  public ResponseEntity<String> postRefreshToken(@RequestBody RefreshTokenRequestDto requestDto){
+    String newToken = refreshTokenService.refreshAccessToken(requestDto.getEmail(), requestDto.getToken());
+
+    return ResponseEntity.ok().header("Authorization", newToken).body("token: "+newToken);
   }
 
 

--- a/src/main/java/com/sparta/deliveryapp/user/controller/UserController.java
+++ b/src/main/java/com/sparta/deliveryapp/user/controller/UserController.java
@@ -51,15 +51,13 @@ public class UserController {
 
     checkValidationErrors(bindingResult);
 
-    String token = userService.signIn(requestDto);
 
-    // 응답 메시지와 JWT 토큰을 담은 DTO 생성
-    SignInResponseDto response = new SignInResponseDto("로그인 성공", token);
+    SignInResponseDto signInResponseDto = userService.signIn(requestDto);
 
     // 응답 반환
     return ResponseEntity.ok()
-        .header("Authorization", token)
-        .body(response);
+        .header("Authorization", signInResponseDto.getAccessToken())
+        .body(signInResponseDto);
   }
 
   @Operation(summary = "수정 기능", description = "유저정보를 수정하는 api, null 로 값을 보내주면 기존의 데이터가 유지되고 받은 값들만 변경이 가능합니다.")

--- a/src/main/java/com/sparta/deliveryapp/user/controller/UserController.java
+++ b/src/main/java/com/sparta/deliveryapp/user/controller/UserController.java
@@ -99,10 +99,9 @@ public class UserController {
 
   @PostMapping("/logout")
   public ResponseEntity<String> logout(@RequestBody SignOutRequestDto requestDto) {
-    String refreshToken = requestDto.getToken();
 
     // 로그아웃 처리
-    userService.logout(requestDto.getEmail(), refreshToken);
+    userService.logout(requestDto.getEmail(), requestDto);
 
     return ResponseEntity.ok("로그아웃 성공");
   }

--- a/src/main/java/com/sparta/deliveryapp/user/controller/UserController.java
+++ b/src/main/java/com/sparta/deliveryapp/user/controller/UserController.java
@@ -97,6 +97,18 @@ public class UserController {
     return ResponseEntity.ok().header("Authorization", newToken).body("token: "+newToken);
   }
 
+  @PostMapping("/logout")
+  public ResponseEntity<String> logout(@RequestBody SignOutRequestDto requestDto) {
+    String refreshToken = requestDto.getToken();
+
+    // 로그아웃 처리
+    userService.logout(requestDto.getEmail(), refreshToken);
+
+    return ResponseEntity.ok("로그아웃 성공");
+  }
+
+
+
 
   // 공통 유효성 검사 메서드
   private void checkValidationErrors(BindingResult bindingResult) {

--- a/src/main/java/com/sparta/deliveryapp/user/dto/RefreshTokenRequestDto.java
+++ b/src/main/java/com/sparta/deliveryapp/user/dto/RefreshTokenRequestDto.java
@@ -1,0 +1,15 @@
+package com.sparta.deliveryapp.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RefreshTokenRequestDto {
+  private String email;
+  private String token;
+}

--- a/src/main/java/com/sparta/deliveryapp/user/dto/SignInResponseDto.java
+++ b/src/main/java/com/sparta/deliveryapp/user/dto/SignInResponseDto.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 public class SignInResponseDto {
 
   private String message;
-  private String token;
+  private String accessToken;
+  private String refreshToken;
 
 }

--- a/src/main/java/com/sparta/deliveryapp/user/dto/SignOutRequestDto.java
+++ b/src/main/java/com/sparta/deliveryapp/user/dto/SignOutRequestDto.java
@@ -12,5 +12,6 @@ import lombok.Setter;
 public class SignOutRequestDto {
 
   private String email;
-  private String token;
+  private String accessToken;
+  private String refreshToken;
 }

--- a/src/main/java/com/sparta/deliveryapp/user/dto/SignOutRequestDto.java
+++ b/src/main/java/com/sparta/deliveryapp/user/dto/SignOutRequestDto.java
@@ -1,0 +1,16 @@
+package com.sparta.deliveryapp.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SignOutRequestDto {
+
+  private String email;
+  private String token;
+}

--- a/src/main/java/com/sparta/deliveryapp/user/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/deliveryapp/user/jwt/JwtAuthorizationFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -21,10 +22,12 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
   private final JwtUtil jwtUtil;
   private final UserDetailsServiceImpl userDetailsService;
+  private final RedisTemplate<String, String> redisTemplate;
 
-  public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService) {
+  public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService, RedisTemplate<String, String> redisTemplate) {
     this.jwtUtil = jwtUtil;
     this.userDetailsService = userDetailsService;
+    this.redisTemplate = redisTemplate;
   }
 
   @Override
@@ -41,6 +44,13 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
       }
 
       Claims info = jwtUtil.getUserInfoFromToken(tokenValue);
+
+      // 블랙리스트 검증: Access Token이 블랙리스트에 있는지 확인
+      if (isTokenBlacklisted(tokenValue)) {
+        log.error("Token is blacklisted");
+        res.sendError(HttpServletResponse.SC_FORBIDDEN, "Token has been invalidated"); // 강제 로그아웃 처리
+        return;
+      }
 
       try {
         setAuthentication(info.getSubject());
@@ -66,5 +76,11 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
   private Authentication createAuthentication(String email) {
     UserDetails userDetails = userDetailsService.loadUserByUsername(email);
     return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+  }
+
+  // 블랙리스트 검증 메소드
+  private boolean isTokenBlacklisted(String tokenValue) {
+    // Access Token이 블랙리스트에 있는지 확인
+    return redisTemplate.opsForValue().get("blacklist:" + tokenValue) != null;
   }
 }

--- a/src/main/java/com/sparta/deliveryapp/user/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/deliveryapp/user/jwt/JwtUtil.java
@@ -84,6 +84,22 @@ public class JwtUtil {
     return false;
   }
 
+  // 리프레시 토큰 생성
+  public String createRefreshToken() {
+    Date date = new Date();
+
+    // 리프레시 토큰의 유효 기간을 7일로 설정 (예시)
+    long refreshTokenTime = 7 * 24 * 60 * 60 * 1000L; // 7일
+
+    return BEARER_PREFIX +
+        Jwts.builder()
+            .setSubject("refreshToken") // 리프레시 토큰의 경우, 보통 이메일을 넣지 않고 고정값을 사용
+            .setExpiration(new Date(date.getTime() + refreshTokenTime)) // 7일 뒤 만료
+            .setIssuedAt(date) // 발급일
+            .signWith(key, signatureAlgorithm)
+            .compact();
+  }
+
   // 토큰에서 사용자 정보 가져오기
   public Claims getUserInfoFromToken(String token) {
     return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();

--- a/src/main/java/com/sparta/deliveryapp/user/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/deliveryapp/user/jwt/JwtUtil.java
@@ -75,7 +75,8 @@ public class JwtUtil {
     } catch (SecurityException | MalformedJwtException | SignatureException e) {
       log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
     } catch (ExpiredJwtException e) {
-      log.error("Expired JWT token, 만료된 JWT token 입니다.");
+      log.warn("Expired JWT token, 만료된 JWT token 입니다. 리프레시 토큰을 확인하세요.");
+      throw e;
     } catch (UnsupportedJwtException e) {
       log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
     } catch (IllegalArgumentException e) {

--- a/src/main/java/com/sparta/deliveryapp/user/service/RefreshTokenService.java
+++ b/src/main/java/com/sparta/deliveryapp/user/service/RefreshTokenService.java
@@ -34,6 +34,12 @@ public class RefreshTokenService {
       throw new CustomException(EXPIRED_REFRESH_TOKEN);
     }
 
+    // 추가. 블랙리스트
+    // 블랙리스트 체크
+    if (isTokenBlacklisted(refreshToken)) {
+      throw new CustomException(INVALID_REFRESH_TOKEN);
+    }
+
     // 2. Redis에 저장된 리프레시 토큰 확인
     String storedRefreshToken = redisTemplate.opsForValue().get("refreshToken:" + email);
     log.info(storedRefreshToken);
@@ -46,5 +52,10 @@ public class RefreshTokenService {
     String newToken = jwtUtil.createToken(email, user.getRole());
 
     return newToken;
+  }
+
+  public boolean isTokenBlacklisted(String refreshToken) {
+    String token = refreshToken.substring(7);  // Bearer " 제거
+    return redisTemplate.hasKey("blacklist:" + token);  // 블랙리스트에 존재하면 true
   }
 }

--- a/src/main/java/com/sparta/deliveryapp/user/service/RefreshTokenService.java
+++ b/src/main/java/com/sparta/deliveryapp/user/service/RefreshTokenService.java
@@ -1,0 +1,50 @@
+package com.sparta.deliveryapp.user.service;
+
+
+import static com.sparta.deliveryapp.commons.exception.ErrorCode.EXPIRED_REFRESH_TOKEN;
+import static com.sparta.deliveryapp.commons.exception.ErrorCode.INVALID_REFRESH_TOKEN;
+import static com.sparta.deliveryapp.commons.exception.ErrorCode.USER_NOT_FOUND;
+
+import com.sparta.deliveryapp.commons.exception.error.CustomException;
+import com.sparta.deliveryapp.user.entity.User;
+import com.sparta.deliveryapp.user.jwt.JwtUtil;
+import com.sparta.deliveryapp.user.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class RefreshTokenService {
+  private final JwtUtil jwtUtil;
+  private final RedisTemplate<String, String> redisTemplate;
+  private final UserRepository userRepository;
+
+  @Autowired
+  public RefreshTokenService(JwtUtil jwtUtil, RedisTemplate<String,String> redisTemplate, UserRepository userRepository){
+    this.jwtUtil = jwtUtil;
+    this.redisTemplate = redisTemplate;
+    this.userRepository = userRepository;
+  }
+
+  public String refreshAccessToken(String email, String refreshToken){
+    // 1. 리프레시 토큰 유효성 검증
+    if(!jwtUtil.validateToken(refreshToken)){
+      throw new CustomException(EXPIRED_REFRESH_TOKEN);
+    }
+
+    // 2. Redis에 저장된 리프레시 토큰 확인
+    String storedRefreshToken = redisTemplate.opsForValue().get("refreshToken:" + email);
+    log.info(storedRefreshToken);
+    if(storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)){
+      throw new CustomException(INVALID_REFRESH_TOKEN);
+    }
+
+    // 3. 새로운 엑게스 토큰 발급
+    User user = userRepository.findByEmail(email).orElseThrow(()-> new CustomException(USER_NOT_FOUND));
+    String newToken = jwtUtil.createToken(email, user.getRole());
+
+    return newToken;
+  }
+}

--- a/src/main/java/com/sparta/deliveryapp/user/service/UserService.java
+++ b/src/main/java/com/sparta/deliveryapp/user/service/UserService.java
@@ -90,6 +90,15 @@ public class UserService {
     return new SignInResponseDto("로그인 성공",accessToken,refreshToken);
   }
 
+  // 로그아웃
+  public void logout(String email, String refreshToken) {
+    log.info("blacklist 등록");
+    redisTemplate.opsForValue().set("blacklist:" + refreshToken.substring(7), email, 7, TimeUnit.DAYS);
+    log.info("refreshToken 삭제");
+    redisTemplate.delete("refreshToken:"+email);
+  }
+
+
   @Transactional
   public void updateUser(String email, UserUpdateRequestDto requestDto, User user) {
     User findUser = userRepository.findByEmail(email)

--- a/src/main/java/com/sparta/deliveryapp/user/service/UserService.java
+++ b/src/main/java/com/sparta/deliveryapp/user/service/UserService.java
@@ -17,6 +17,7 @@ import com.sparta.deliveryapp.store.entity.Store;
 import com.sparta.deliveryapp.store.repository.StoreRepository;
 import com.sparta.deliveryapp.user.dto.SignInRequestDto;
 import com.sparta.deliveryapp.user.dto.SignInResponseDto;
+import com.sparta.deliveryapp.user.dto.SignOutRequestDto;
 import com.sparta.deliveryapp.user.dto.SignUpRequestDto;
 import com.sparta.deliveryapp.user.dto.UserResponseDto;
 import com.sparta.deliveryapp.user.dto.UserUpdateRequestDto;
@@ -91,10 +92,11 @@ public class UserService {
   }
 
   // 로그아웃
-  public void logout(String email, String refreshToken) {
+  public void logout(String email, SignOutRequestDto requestDto) {
     log.info("blacklist 등록");
-    redisTemplate.opsForValue().set("blacklist:" + refreshToken.substring(7), email, 7, TimeUnit.DAYS);
-    log.info("refreshToken 삭제");
+    redisTemplate.opsForValue().set("blacklist:" + requestDto.getAccessToken(), email, 7, TimeUnit.DAYS);
+    redisTemplate.opsForValue().set("blacklist:" + requestDto.getRefreshToken(), email, 7, TimeUnit.DAYS);
+
     redisTemplate.delete("refreshToken:"+email);
   }
 

--- a/src/main/java/com/sparta/deliveryapp/user/service/UserService.java
+++ b/src/main/java/com/sparta/deliveryapp/user/service/UserService.java
@@ -1,5 +1,11 @@
 package com.sparta.deliveryapp.user.service;
 
+import static com.sparta.deliveryapp.commons.exception.ErrorCode.ACCESS_DENIED;
+import static com.sparta.deliveryapp.commons.exception.ErrorCode.EMAIL_ALREADY_REGISTERED;
+import static com.sparta.deliveryapp.commons.exception.ErrorCode.PASSWORD_NOT_MATCH;
+import static com.sparta.deliveryapp.commons.exception.ErrorCode.USER_DELETED;
+import static com.sparta.deliveryapp.commons.exception.ErrorCode.USER_NOT_FOUND;
+
 import com.sparta.deliveryapp.ai.AIRepository;
 import com.sparta.deliveryapp.commons.exception.error.CustomException;
 import com.sparta.deliveryapp.menu.repository.MenuRepository;
@@ -10,6 +16,7 @@ import com.sparta.deliveryapp.review.repository.ReviewRepository;
 import com.sparta.deliveryapp.store.entity.Store;
 import com.sparta.deliveryapp.store.repository.StoreRepository;
 import com.sparta.deliveryapp.user.dto.SignInRequestDto;
+import com.sparta.deliveryapp.user.dto.SignInResponseDto;
 import com.sparta.deliveryapp.user.dto.SignUpRequestDto;
 import com.sparta.deliveryapp.user.dto.UserResponseDto;
 import com.sparta.deliveryapp.user.dto.UserUpdateRequestDto;
@@ -18,19 +25,18 @@ import com.sparta.deliveryapp.user.jwt.JwtUtil;
 import com.sparta.deliveryapp.user.repository.UserRepository;
 import com.sparta.deliveryapp.user.security.UserDetailsImpl;
 import com.sparta.deliveryapp.util.NullAwareBeanUtils;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
-import static com.sparta.deliveryapp.commons.exception.ErrorCode.*;
 
 @Service
 @Slf4j
@@ -47,6 +53,7 @@ public class UserService {
   private final StoreRepository storeRepository;
   private final AIRepository aiRepository;
   private final JwtUtil jwtUtil;
+  private final RedisTemplate<String, String> redisTemplate;
 
 
   @Transactional
@@ -64,7 +71,7 @@ public class UserService {
     userRepository.save(new User(requestDto, password));
   }
 
-  public String signIn(SignInRequestDto requestDto) {
+  public SignInResponseDto signIn(SignInRequestDto requestDto) {
     User user = userRepository.findByEmail(requestDto.getEmail())
         .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
@@ -76,9 +83,11 @@ public class UserService {
       throw new CustomException(PASSWORD_NOT_MATCH);
     }
 
-    String token = jwtUtil.createToken(user.getEmail(), user.getRole());
+    String accessToken = jwtUtil.createToken(user.getEmail(), user.getRole());
+    String refreshToken = jwtUtil.createRefreshToken();
+    redisTemplate.opsForValue().set("refreshToken:" + user.getEmail(), refreshToken, 7, TimeUnit.DAYS);
 
-    return token;
+    return new SignInResponseDto("로그인 성공",accessToken,refreshToken);
   }
 
   @Transactional

--- a/src/main/java/com/sparta/deliveryapp/user/service/UserService.java
+++ b/src/main/java/com/sparta/deliveryapp/user/service/UserService.java
@@ -85,7 +85,7 @@ public class UserService {
 
     String accessToken = jwtUtil.createToken(user.getEmail(), user.getRole());
     String refreshToken = jwtUtil.createRefreshToken();
-    redisTemplate.opsForValue().set("refreshToken:" + user.getEmail(), refreshToken, 7, TimeUnit.DAYS);
+    redisTemplate.opsForValue().set("refreshToken:" + user.getEmail(), refreshToken.substring(7), 7, TimeUnit.DAYS);
 
     return new SignInResponseDto("로그인 성공",accessToken,refreshToken);
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,7 @@ spring:
     secretKey: ${SECRET_KEY:defaultSecretKey}
   gemini:
     secretKey: ${GEMINI_KEY:defaultSecretKey}
+
 ---
 spring:
   config:
@@ -56,3 +57,12 @@ api-key:
 springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
+
+---
+spring:
+  data:
+    redis:
+      host: ${REDIS_HOST}   # Redis 서버 주소 (localhost 또는 외부 서버)
+      port: ${REDIS_PORT}   # Redis 포트 (기본적으로 6379)
+      password: ${REDIS_PASSWORD}  # Redis 서버 비밀번호 (requirepass 설정에 맞춰야 함)
+      username: ${REDIS_USERNAME}


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ x] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용

1️⃣ 로그인
사용자가 로그인하면 액세스 토큰과 리프레시 토큰을 발급
액세스 토큰: 클라이언트(브라우저, 앱 등)에 전달
리프레시 토큰: Redis에 저장

2️⃣ API 요청 처리
클라이언트는 요청할 때 액세스 토큰을 포함하여 보냄
서버는 액세스 토큰을 검증하여 처리

3️⃣ 액세스 토큰 만료 시 (재발급 과정)
클라이언트가 액세스 토큰 만료 시, Redis에서 저장된 리프레시 토큰을 검증하여 새로운 액세스 토큰을 발급

4️⃣ 로그아웃
Redis에서 해당 사용자의 리프레시 토큰을 삭제
블랙리스트 방식으로 액세스 토큰 무효화 가능

